### PR TITLE
Feature/#1 post

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-HELP.md
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar

--- a/src/main/java/site/syncnote/blog/Blog.java
+++ b/src/main/java/site/syncnote/blog/Blog.java
@@ -1,0 +1,20 @@
+package site.syncnote.blog;
+
+import lombok.Builder;
+import lombok.Getter;
+import site.syncnote.member.Member;
+import site.syncnote.post.Post;
+
+import java.util.List;
+
+@Getter
+public class Blog {
+    private Member owner;
+    private List<Post> posts;
+
+    @Builder
+    public Blog(Member owner, List<Post> posts) {
+        this.owner = owner;
+        this.posts = posts;
+    }
+}

--- a/src/main/java/site/syncnote/hashtag/HashTag.java
+++ b/src/main/java/site/syncnote/hashtag/HashTag.java
@@ -1,6 +1,9 @@
 package site.syncnote.hashtag;
 
 import lombok.Getter;
+
+import java.util.Objects;
+
 @Getter
 public class HashTag {
     private final String name;
@@ -12,5 +15,18 @@ public class HashTag {
     }
 
     public void delete() {
-        this.deleted = true;    }
+        this.deleted = true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof HashTag hashTag)) return false;
+        return deleted == hashTag.deleted && Objects.equals(name, hashTag.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, deleted);
+    }
 }

--- a/src/main/java/site/syncnote/hashtag/HashTag.java
+++ b/src/main/java/site/syncnote/hashtag/HashTag.java
@@ -1,0 +1,16 @@
+package site.syncnote.hashtag;
+
+import lombok.Getter;
+@Getter
+public class HashTag {
+    private final String name;
+    private boolean deleted;
+
+    public HashTag(String name) {
+        this.name = name;
+        this.deleted = false;
+    }
+
+    public void delete() {
+        this.deleted = true;    }
+}

--- a/src/main/java/site/syncnote/hashtag/HashTagService.java
+++ b/src/main/java/site/syncnote/hashtag/HashTagService.java
@@ -1,0 +1,17 @@
+package site.syncnote.hashtag;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class HashTagService {
+    private final Map<String, HashTag> map = new HashMap<>();
+
+    public HashTag find(String name) {
+        if (map.containsKey(name)) {
+            return map.get(name);
+        }
+        HashTag hashTag = new HashTag(name);
+        map.put(name, hashTag);
+        return hashTag;
+    }
+}

--- a/src/main/java/site/syncnote/member/Member.java
+++ b/src/main/java/site/syncnote/member/Member.java
@@ -1,0 +1,30 @@
+package site.syncnote.member;
+
+import lombok.Getter;
+
+@Getter
+public class Member {
+    private final String email;
+    private String name;
+    private String password;
+    private boolean unsubscribed;
+
+    public Member(String email, String name, String password) {
+        this.email = email;
+        this.name = name;
+        this.password = password;
+        this.unsubscribed = false;
+    }
+
+    public void edit(String name, String password) {
+        if (unsubscribed) {
+            throw new IllegalArgumentException();
+        }
+        this.name = name;
+        this.password = password;
+    }
+
+    public void unsubscribed() {
+        this.unsubscribed = true;
+    }
+}

--- a/src/main/java/site/syncnote/member/Member.java
+++ b/src/main/java/site/syncnote/member/Member.java
@@ -1,5 +1,6 @@
 package site.syncnote.member;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -9,6 +10,7 @@ public class Member {
     private String password;
     private boolean unsubscribed;
 
+    @Builder
     public Member(String email, String name, String password) {
         this.email = email;
         this.name = name;

--- a/src/main/java/site/syncnote/member/Member.java
+++ b/src/main/java/site/syncnote/member/Member.java
@@ -8,25 +8,25 @@ public class Member {
     private final String email;
     private String name;
     private String password;
-    private boolean unsubscribed;
+    private boolean deleted;
 
     @Builder
     public Member(String email, String name, String password) {
         this.email = email;
         this.name = name;
         this.password = password;
-        this.unsubscribed = false;
+        this.deleted = false;
     }
 
-    public void edit(String name, String password) {
-        if (unsubscribed) {
+    public void updateMemberInfo(String name, String password) {
+        if (deleted) {
             throw new IllegalArgumentException();
         }
         this.name = name;
         this.password = password;
     }
 
-    public void unsubscribed() {
-        this.unsubscribed = true;
+    public void withdraw() {
+        this.deleted = true;
     }
 }

--- a/src/main/java/site/syncnote/post/Post.java
+++ b/src/main/java/site/syncnote/post/Post.java
@@ -2,6 +2,7 @@ package site.syncnote.post;
 
 import lombok.Builder;
 import lombok.Getter;
+import site.syncnote.hashtag.HashTag;
 
 import java.util.List;
 
@@ -9,12 +10,12 @@ import java.util.List;
 public class Post {
     private String title;
     private String content;
-    private List<String> hashTags;
+    private List<HashTag> hashTags;
     private String author;
     private boolean deleted;
 
     @Builder
-    public Post(String title, String content, List<String> hashTags, String author) {
+    public Post(String title, String content, List<HashTag> hashTags, String author) {
         this.title = title;
         this.content = content;
         this.hashTags = hashTags;

--- a/src/main/java/site/syncnote/post/Post.java
+++ b/src/main/java/site/syncnote/post/Post.java
@@ -3,6 +3,7 @@ package site.syncnote.post;
 import lombok.Builder;
 import lombok.Getter;
 import site.syncnote.hashtag.HashTag;
+import site.syncnote.member.Member;
 
 import java.util.List;
 
@@ -11,11 +12,11 @@ public class Post {
     private String title;
     private String content;
     private List<HashTag> hashTags;
-    private String author;
+    private Member author;
     private boolean deleted;
 
     @Builder
-    public Post(String title, String content, List<HashTag> hashTags, String author) {
+    public Post(String title, String content, List<HashTag> hashTags, Member author) {
         this.title = title;
         this.content = content;
         verifyHashTags(hashTags);

--- a/src/main/java/site/syncnote/post/Post.java
+++ b/src/main/java/site/syncnote/post/Post.java
@@ -12,7 +12,7 @@ public class Post {
     private String title;
     private String content;
     private List<HashTag> hashTags;
-    private Member author;
+    private final Member author;
     private boolean deleted;
 
     @Builder

--- a/src/main/java/site/syncnote/post/Post.java
+++ b/src/main/java/site/syncnote/post/Post.java
@@ -18,9 +18,16 @@ public class Post {
     public Post(String title, String content, List<HashTag> hashTags, String author) {
         this.title = title;
         this.content = content;
+        verifyHashTags(hashTags);
         this.hashTags = hashTags;
         this.author = author;
         this.deleted = false;
+    }
+
+    private void verifyHashTags(List<HashTag> hashTags) {
+        if (hashTags != null && hashTags.size() > 5) {
+            throw new IllegalArgumentException();
+        }
     }
 
     public void edit(String title, String content, List<HashTag> hashTags) {
@@ -35,5 +42,4 @@ public class Post {
     public void delete() {
         this.deleted = true;
     }
-
 }

--- a/src/main/java/site/syncnote/post/Post.java
+++ b/src/main/java/site/syncnote/post/Post.java
@@ -23,15 +23,17 @@ public class Post {
         this.deleted = false;
     }
 
-    public void edit(String title, String content) {
+    public void edit(String title, String content, List<HashTag> hashTags) {
         if (deleted) {
             throw new IllegalArgumentException();
         }
         this.title = title;
         this.content = content;
+        this.hashTags = hashTags;
     }
 
     public void delete() {
         this.deleted = true;
     }
+
 }

--- a/src/main/java/site/syncnote/post/Post.java
+++ b/src/main/java/site/syncnote/post/Post.java
@@ -25,19 +25,20 @@ public class Post {
         this.deleted = false;
     }
 
-    private void verifyHashTags(List<HashTag> hashTags) {
-        if (hashTags != null && hashTags.size() > 5) {
-            throw new IllegalArgumentException();
-        }
-    }
-
     public void edit(String title, String content, List<HashTag> hashTags) {
         if (deleted) {
             throw new IllegalArgumentException();
         }
+        verifyHashTags(hashTags);
         this.title = title;
         this.content = content;
         this.hashTags = hashTags;
+    }
+
+    private void verifyHashTags(List<HashTag> hashTags) {
+        if (hashTags != null && hashTags.size() > 5) {
+            throw new IllegalArgumentException();
+        }
     }
 
     public void delete() {

--- a/src/test/java/site/syncnote/blog/BlogTest.java
+++ b/src/test/java/site/syncnote/blog/BlogTest.java
@@ -1,6 +1,5 @@
 package site.syncnote.blog;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import site.syncnote.member.Member;
@@ -8,13 +7,12 @@ import site.syncnote.post.Post;
 
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class BlogTest {
-    @DisplayName("sample test")
+    @DisplayName("블로그를 생성한다.")
     @Test
-    void testMethodNameHere() {
+    void create_blog() {
         // given
         Member owner = Member.builder()
             .email("test@gmail.com")

--- a/src/test/java/site/syncnote/blog/BlogTest.java
+++ b/src/test/java/site/syncnote/blog/BlogTest.java
@@ -1,0 +1,41 @@
+package site.syncnote.blog;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import site.syncnote.member.Member;
+import site.syncnote.post.Post;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class BlogTest {
+    @DisplayName("sample test")
+    @Test
+    void testMethodNameHere() {
+        // given
+        Member owner = Member.builder()
+            .email("test@gmail.com")
+            .name("tester")
+            .password("1234")
+            .build();
+        Post post = Post.builder()
+            .title("title")
+            .content("content")
+            .author(owner)
+            .build();
+        List<Post> posts = List.of(post);
+
+        // when
+        Blog blog = Blog.builder()
+            .owner(owner)
+            .posts(posts)
+            .build();
+
+        // then
+        assertThat(blog.getOwner()).isEqualTo(owner);
+        assertThat(blog.getPosts()).containsExactly(post);
+    }
+}

--- a/src/test/java/site/syncnote/hashtag/HashTagServiceTest.java
+++ b/src/test/java/site/syncnote/hashtag/HashTagServiceTest.java
@@ -1,0 +1,37 @@
+package site.syncnote.hashtag;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HashTagServiceTest {
+
+    @DisplayName("해시태그를 찾는다.")
+    @Test
+    void find() {
+        // given
+        String hashTagName = "에세이";
+        // when
+        HashTagService hashTagService = new HashTagService();
+        HashTag hashTag = hashTagService.find(hashTagName);
+
+        // then
+        assertThat(hashTag.getName()).isEqualTo(hashTagName);
+    }
+
+    @DisplayName("기존에 생성한 해시태그는 재사용한다.")
+    @Test
+    void 해시태그가_이미_존재하면_재사용한다() {
+        // given
+        String hashTagName = "에세이";
+
+        // when
+        HashTagService hashTagService = new HashTagService();
+        HashTag hashTag = hashTagService.find(hashTagName);
+        HashTag hashTag2 = hashTagService.find(hashTagName);
+
+        // then
+        assertThat(hashTag).isEqualTo(hashTag2);
+    }
+}

--- a/src/test/java/site/syncnote/hashtag/HashTagServiceTest.java
+++ b/src/test/java/site/syncnote/hashtag/HashTagServiceTest.java
@@ -22,7 +22,7 @@ class HashTagServiceTest {
 
     @DisplayName("기존에 생성한 해시태그는 재사용한다.")
     @Test
-    void 해시태그가_이미_존재하면_재사용한다() {
+    void If_hashTag_already_exists_reuse() {
         // given
         String hashTagName = "에세이";
 

--- a/src/test/java/site/syncnote/hashtag/HashTagTest.java
+++ b/src/test/java/site/syncnote/hashtag/HashTagTest.java
@@ -1,0 +1,33 @@
+package site.syncnote.hashtag;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HashTagTest {
+
+    @DisplayName("해시태그를 생성할 수 있다.")
+    @Test
+    void create_hashtag() {
+        // given && when
+        HashTag hashTag = new HashTag("에세이");
+
+        // then
+        assertThat(hashTag.getName()).isEqualTo("에세이");
+        assertThat(hashTag.isDeleted()).isFalse();
+    }
+
+    @DisplayName("해시태그를 삭제할 수 있다.")
+    @Test
+    void delete() {
+        // given
+        HashTag hashTag = new HashTag("에세이");
+
+        // when
+        hashTag.delete();
+
+        // then
+        assertThat(hashTag.isDeleted()).isTrue();
+    }
+}

--- a/src/test/java/site/syncnote/hashtag/HashTagTest.java
+++ b/src/test/java/site/syncnote/hashtag/HashTagTest.java
@@ -10,11 +10,14 @@ class HashTagTest {
     @DisplayName("해시태그를 생성할 수 있다.")
     @Test
     void create_hashtag() {
-        // given && when
-        HashTag hashTag = new HashTag("에세이");
+        // given
+        String hashTagName = "에세이";
+
+        // when
+        HashTag hashTag = new HashTag(hashTagName);
 
         // then
-        assertThat(hashTag.getName()).isEqualTo("에세이");
+        assertThat(hashTag.getName()).isEqualTo(hashTagName);
         assertThat(hashTag.isDeleted()).isFalse();
     }
 

--- a/src/test/java/site/syncnote/member/MemberTest.java
+++ b/src/test/java/site/syncnote/member/MemberTest.java
@@ -1,0 +1,77 @@
+package site.syncnote.member;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class MemberTest {
+
+    @DisplayName("회원은 이메일과 비밀번호와 이름으로 만든다.")
+    @Test
+    void create_member() {
+        // given
+        String mail = "test@gmail.com";
+        String name = "tester";
+        String password = "1234";
+
+        // when
+        Member tester = new Member(mail, name, password);
+
+        // then
+        assertThat(tester.getEmail()).isEqualTo(mail);
+        assertThat(tester.getName()).isEqualTo(name);
+        assertThat(tester.getPassword()).isEqualTo(password);
+    }
+
+    @DisplayName("회원 정보를 수정할 수 있다.")
+    @Test
+    void edit() {
+        // given
+        String mail = "test@gmail.com";
+        String name = "tester";
+        String password = "1234";
+        Member tester = new Member(mail, name, password);
+
+        // when
+        tester.edit("테스터 변경", "12345!");
+
+        // then
+        assertThat(tester.getName()).isEqualTo("테스터 변경");
+        assertThat(tester.getPassword()).isEqualTo("12345!");
+    }
+
+    @DisplayName("회원 정보를 수정할 수 없다.")
+    @Test
+    void edit_fail_if_member_unsubscribed() {
+        // given
+        String mail = "test@gmail.com";
+        String name = "tester";
+        String password = "1234";
+        Member tester = new Member(mail, name, password);
+
+        // when
+        ReflectionTestUtils.setField(tester, "unsubscribed", true);
+
+        // then
+        assertThrows(IllegalArgumentException.class, () -> tester.edit("테스터", "12345"));
+    }
+
+    @DisplayName("회원은 탈퇴할 수 있다.")
+    @Test
+    void unsubscribed() {
+        // given
+        String mail = "test@gmail.com";
+        String name = "tester";
+        String password = "1234";
+        Member tester = new Member(mail, name, password);
+
+        // when
+        ReflectionTestUtils.setField(tester, "unsubscribed", true);
+
+        // then
+        assertThat(tester.isUnsubscribed()).isTrue();
+    }
+}

--- a/src/test/java/site/syncnote/member/MemberTest.java
+++ b/src/test/java/site/syncnote/member/MemberTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class MemberTest {
 
-    @DisplayName("회원은 이메일과 비밀번호와 이름으로 만든다.")
+    @DisplayName("회원을 생성한다.")
     @Test
     void create_member() {
         // given
@@ -18,7 +18,11 @@ class MemberTest {
         String password = "1234";
 
         // when
-        Member tester = new Member(mail, name, password);
+        Member tester = Member.builder()
+            .email(mail)
+            .name(name)
+            .password(password)
+            .build();
 
         // then
         assertThat(tester.getEmail()).isEqualTo(mail);
@@ -26,14 +30,18 @@ class MemberTest {
         assertThat(tester.getPassword()).isEqualTo(password);
     }
 
-    @DisplayName("회원 정보를 수정할 수 있다.")
+    @DisplayName("회원은 비밀번호를 수정할 수 있다.")
     @Test
     void edit() {
         // given
         String mail = "test@gmail.com";
         String name = "tester";
         String password = "1234";
-        Member tester = new Member(mail, name, password);
+        Member tester = Member.builder()
+            .email(mail)
+            .name(name)
+            .password(password)
+            .build();
 
         // when
         tester.edit("테스터 변경", "12345!");
@@ -50,7 +58,11 @@ class MemberTest {
         String mail = "test@gmail.com";
         String name = "tester";
         String password = "1234";
-        Member tester = new Member(mail, name, password);
+        Member tester = Member.builder()
+            .email(mail)
+            .name(name)
+            .password(password)
+            .build();
 
         // when
         ReflectionTestUtils.setField(tester, "unsubscribed", true);

--- a/src/test/java/site/syncnote/member/MemberTest.java
+++ b/src/test/java/site/syncnote/member/MemberTest.java
@@ -44,7 +44,7 @@ class MemberTest {
             .build();
 
         // when
-        tester.edit("테스터 변경", "12345!");
+        tester.updateMemberInfo("테스터 변경", "12345!");
 
         // then
         assertThat(tester.getName()).isEqualTo("테스터 변경");
@@ -65,10 +65,10 @@ class MemberTest {
             .build();
 
         // when
-        ReflectionTestUtils.setField(tester, "unsubscribed", true);
+        ReflectionTestUtils.setField(tester, "deleted", true);
 
         // then
-        assertThrows(IllegalArgumentException.class, () -> tester.edit("테스터", "12345"));
+        assertThrows(IllegalArgumentException.class, () -> tester.updateMemberInfo("테스터", "12345"));
     }
 
     @DisplayName("회원은 탈퇴할 수 있다.")
@@ -81,9 +81,9 @@ class MemberTest {
         Member tester = new Member(mail, name, password);
 
         // when
-        ReflectionTestUtils.setField(tester, "unsubscribed", true);
+        ReflectionTestUtils.setField(tester, "deleted", true);
 
         // then
-        assertThat(tester.isUnsubscribed()).isTrue();
+        assertThat(tester.isDeleted()).isTrue();
     }
 }

--- a/src/test/java/site/syncnote/post/PostTest.java
+++ b/src/test/java/site/syncnote/post/PostTest.java
@@ -38,6 +38,30 @@ class PostTest {
         assertThat(post.isDeleted()).isFalse();
     }
 
+    @DisplayName("해시태그는 5개이상 추가할 수 없다.")
+    @Test
+    void createPost_fail_if_hashtag_more_then_five() {
+        // given
+        String title = "나의 이야기";
+        String content = "나의 이야기 본문";
+        String author = "나숙희";
+        HashTag hashTag = new HashTag("에세이");
+        HashTag hashTag2 = new HashTag("산수");
+        HashTag hashTag3 = new HashTag("산문");
+        HashTag hashTag4 = new HashTag("수필");
+        HashTag hashTag5 = new HashTag("소설");
+        HashTag hashTag6 = new HashTag("시");
+        List<HashTag> hashtags = List.of(hashTag, hashTag2, hashTag3, hashTag4, hashTag5, hashTag6);
+
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> Post.builder()
+            .title(title)
+            .content(content)
+            .author(author)
+            .hashTags(hashtags)
+            .build());
+    }
+
     @DisplayName("회원이 글을 수정한다.")
     @Test
     void edit() {

--- a/src/test/java/site/syncnote/post/PostTest.java
+++ b/src/test/java/site/syncnote/post/PostTest.java
@@ -3,6 +3,7 @@ package site.syncnote.post;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
+import site.syncnote.hashtag.HashTag;
 
 import java.util.List;
 
@@ -18,7 +19,8 @@ class PostTest {
         String title = "나의 이야기";
         String content = "나의 이야기 본문";
         String author = "나숙희";
-        List<String> hashtags = List.of("에세이");
+        HashTag hashTag = new HashTag("에세이");
+        List<HashTag> hashtags = List.of(hashTag);
 
         // when
         Post post = Post.builder()
@@ -32,7 +34,7 @@ class PostTest {
         assertThat(post.getTitle()).isEqualTo(title);
         assertThat(post.getAuthor()).isEqualTo(author);
         assertThat(post.getContent()).isEqualTo(content);
-        assertThat(post.getHashTags()).containsExactly("에세이");
+        assertThat(post.getHashTags()).containsExactly(hashTag);
         assertThat(post.isDeleted()).isFalse();
     }
 

--- a/src/test/java/site/syncnote/post/PostTest.java
+++ b/src/test/java/site/syncnote/post/PostTest.java
@@ -42,18 +42,22 @@ class PostTest {
     @Test
     void edit() {
         // given
+        HashTag hashTag = new HashTag("에세이");
         Post post = Post.builder()
             .title("나의 이야기")
             .content("나의 이야기 본문")
             .author("나숙희")
+            .hashTags(List.of(hashTag))
             .build();
 
         // when
-        post.edit("너의 이야기","너의 이야기 본문");
+        HashTag newHashTag = new HashTag("산문");
+        post.edit("너의 이야기", "너의 이야기 본문", List.of(newHashTag));
 
         // then
         assertThat(post.getTitle()).isEqualTo("너의 이야기");
         assertThat(post.getContent()).isEqualTo("너의 이야기 본문");
+        assertThat(post.getHashTags()).containsExactly(newHashTag);
     }
 
     @DisplayName("글이 삭제된 경우 수정할 수 없다.")
@@ -65,9 +69,9 @@ class PostTest {
             .content("나의 이야기 본문")
             .author("나숙희")
             .build();
-        ReflectionTestUtils.setField(post,"deleted",true);
+        ReflectionTestUtils.setField(post, "deleted", true);
 
         // when & then
-        assertThrows(IllegalArgumentException.class,() ->post.edit("너의 이야기","본문"));
+        assertThrows(IllegalArgumentException.class, () -> post.edit("너의 이야기", "본문", List.of()));
     }
 }

--- a/src/test/java/site/syncnote/post/PostTest.java
+++ b/src/test/java/site/syncnote/post/PostTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 import site.syncnote.hashtag.HashTag;
+import site.syncnote.member.Member;
 
 import java.util.List;
 
@@ -18,7 +19,8 @@ class PostTest {
         // given
         String title = "나의 이야기";
         String content = "나의 이야기 본문";
-        String author = "나숙희";
+        String name = "나숙희";
+        Member member = new Member("test@gmail.com", name, "1234");
         HashTag hashTag = new HashTag("에세이");
         List<HashTag> hashtags = List.of(hashTag);
 
@@ -26,13 +28,13 @@ class PostTest {
         Post post = Post.builder()
             .title(title)
             .content(content)
-            .author(author)
+            .author(member)
             .hashTags(hashtags)
             .build();
 
         // then
         assertThat(post.getTitle()).isEqualTo(title);
-        assertThat(post.getAuthor()).isEqualTo(author);
+        assertThat(post.getAuthor()).isEqualTo(member);
         assertThat(post.getContent()).isEqualTo(content);
         assertThat(post.getHashTags()).containsExactly(hashTag);
         assertThat(post.isDeleted()).isFalse();
@@ -44,7 +46,8 @@ class PostTest {
         // given
         String title = "나의 이야기";
         String content = "나의 이야기 본문";
-        String author = "나숙희";
+        String name = "나숙희";
+        Member member = new Member("test@gmail.com", name, "1234");
         HashTag hashTag = new HashTag("에세이");
         HashTag hashTag2 = new HashTag("산수");
         HashTag hashTag3 = new HashTag("산문");
@@ -57,7 +60,7 @@ class PostTest {
         assertThrows(IllegalArgumentException.class, () -> Post.builder()
             .title(title)
             .content(content)
-            .author(author)
+            .author(member)
             .hashTags(hashtags)
             .build());
     }
@@ -66,11 +69,13 @@ class PostTest {
     @Test
     void edit() {
         // given
+        String name = "나숙희";
+        Member member = new Member("test@gmail.com", name, "1234");
         HashTag hashTag = new HashTag("에세이");
         Post post = Post.builder()
             .title("나의 이야기")
             .content("나의 이야기 본문")
-            .author("나숙희")
+            .author(member)
             .hashTags(List.of(hashTag))
             .build();
 
@@ -88,10 +93,12 @@ class PostTest {
     @Test
     void edit_fail_if_post_deleted() {
         // given
+        String name = "나숙희";
+        Member member = new Member("test@gmail.com", name, "1234");
         Post post = Post.builder()
             .title("나의 이야기")
             .content("나의 이야기 본문")
-            .author("나숙희")
+            .author(member)
             .build();
         ReflectionTestUtils.setField(post, "deleted", true);
 

--- a/src/test/java/site/syncnote/post/PostTest.java
+++ b/src/test/java/site/syncnote/post/PostTest.java
@@ -14,7 +14,7 @@ class PostTest {
 
     @DisplayName("회원이 제목, 본문, 해시태그로 글을 작성한다.")
     @Test
-    void creatPost() {
+    void creat_post() {
         // given
         String title = "나의 이야기";
         String content = "나의 이야기 본문";

--- a/src/test/java/site/syncnote/post/PostTest.java
+++ b/src/test/java/site/syncnote/post/PostTest.java
@@ -89,6 +89,29 @@ class PostTest {
         assertThat(post.getHashTags()).containsExactly(newHashTag);
     }
 
+    @DisplayName("해시태그가 5개이상인 경우 글을 수정할 수 없다.")
+    @Test
+    void edit_fail_if_hashTag_more_then_five() {
+        // given
+        String name = "나숙희";
+        Member member = new Member("test@gmail.com", name, "1234");
+        Post post = Post.builder()
+            .title("나의 이야기")
+            .content("나의 이야기 본문")
+            .author(member)
+            .build();
+        HashTag newHashTag = new HashTag("산문");
+        HashTag newHashTag2 = new HashTag("에세이");
+        HashTag newHashTag3 = new HashTag("시");
+        HashTag newHashTag4 = new HashTag("소설");
+        HashTag newHashTag5 = new HashTag("수필");
+        HashTag newHashTag6 = new HashTag("산수");
+        List<HashTag> newHashTags = List.of(newHashTag, newHashTag2, newHashTag3, newHashTag4, newHashTag5, newHashTag6);
+
+        // when
+        assertThrows(IllegalArgumentException.class, () -> post.edit("너의 이야기", "너의 이야기 본문", newHashTags));
+    }
+
     @DisplayName("글이 삭제된 경우 수정할 수 없다.")
     @Test
     void edit_fail_if_post_deleted() {


### PR DESCRIPTION
### 구현 된 것

글 
 - 회원은 글을 작성할 수 있다.
 - 회원은 글을 작성할 때 해시 태그를 5개 추가할 수 있다.
 - 회원은 본인이 작성한 글을 수정할 수 있다.
 - 회원은 본인이 작성한 글을 삭제할 수 있다.
 - 회원은 글을 수정할 때 해시 태그를 추가하거나 삭제할 수 있다.

해시태그
-  회원이 해시태그를 추가할 때 기존에 없는 해시태그이면 새로 만든다.
-  회원이 해시태그를 추가할 때 기존에 있는 해시태그이면 기존에 해시태그를 사용한다.

회원(member)
-  회원은 비밀번호를 수정할 수 있다.
-  회원은 탈퇴할 수 있다.

### 구현되지 않은 것

우선순위가 2순위 였던 댓글의 구현은 추후에 하겠습니다.

